### PR TITLE
Fix for installation on macOS Ventura

### DIFF
--- a/pgplot.rb
+++ b/pgplot.rb
@@ -38,6 +38,10 @@ class Pgplot < Formula
     ENV.deparallelize
     ENV.append "CPPFLAGS", "-DPG_PPU"
 
+    if (system 'sw_vers -productVersion').to_f >= 13.0
+      ENV.append "CPPFLAGS", "-mmacosx-version-min=12.4"
+    end
+
     # re-hardcode the share dir
     inreplace "src/grgfil.f", "/usr/local/pgplot", share
     # perl may not be in /usr/local
@@ -59,7 +63,7 @@ class Pgplot < Formula
       FFLAGD=""
       CCOMPL="#{ENV.cc}"
       CFLAGC="#{ENV.cppflags}"
-      CFLAGD=""
+      CFLAGD="#{ENV.cppflags}"
       PGBIND_FLAGS="bsd"
       LIBS="#{ENV.ldflags} -lX11"
       MOTIF_LIBS=""


### PR DESCRIPTION
 Hi @kazuakiyama, I'm working with @rmutel and ran into issues installing pgplot and difmap on MacOS Ventura (v13.0.1 on MacBook Pro M1). I managed to modify your scripts to allow for installation. The error is primarily due to the make files for both pgplot and difmap handing the C compiler GCC the OS version (seemingly pointlessly). Since the latest version of GCC doesn't understand an input of anything above 12.4.x, it breaks. I made modifications to check the current version and override the appropriate flag if necessary. This shouldn't impact anyone below Ventura. See the pull request on the [difmap repository](https://github.com/WWGolay/homebrew-difmap) as well. 

Cheers,

WWG